### PR TITLE
Clean up cansim package

### DIFF
--- a/R/cansim.R
+++ b/R/cansim.R
@@ -51,7 +51,7 @@ adjust_cansim_values_by_variable <-function(data,var){
   normailze_cansim_values(data)
 }
 
-#' normailzes cancsim values by setting all units to counts/dollars instead of millions, etc.
+#' normalizes CANSIM values by setting all units to counts/dollars instead of millions, etc.
 #' if "replace" is true, it will replace the VALUE field with normailzed values and drop the scale columns,
 #' otherwise it keeps the scale columns and creased a new column names "NORMALIZED_VALUE" with the normalized value
 #' @export

--- a/R/cansim.R
+++ b/R/cansim.R
@@ -160,13 +160,13 @@ get_cansim_ndm <- function(cansimTableNumber,language="english"){
                               na=na_strings,
                               locale=readr::locale(encoding="UTF8"),
                               col_types = list(.default = "c")) %>%
-      mutate(VALUE=as.numeric(VALUE))
+      dplyr::mutate(VALUE=as.numeric(VALUE))
     else
       data <- readr::read_csv2(unz(path, paste0(base_table, ".csv")),
                                na=na_strings,
                                locale=readr::locale(encoding="UTF8"),
                                col_types = list(.default = "c")) %>%
-      mutate(VALEUR=as.numeric(VALEUR))
+      dplyr::mutate(VALEUR=as.numeric(VALEUR))
     saveRDS(data,file=path)
   }
   readRDS(file=path)

--- a/README.md
+++ b/README.md
@@ -1,34 +1,81 @@
 # cansim
-Wrapper to access CANSIM data
+R package to download Statistics Canada CANSIM/NDM tables.
 
-Inspired by the [CANSIM2R package](https://cran.r-project.org/web/packages/CANSIM2R/index.html), with a
-couple of modifications to better fit my needs. Tables are cached for the duration of the session to
-avoid waits when recompiling code, the "raw" option is the default and variables get automatically read
-as numeric/character as appropriate. On read it uses "Windows-1254" ecoding to avoid issues with some labels messing
-with R. The package also contains a convenience function that will re-scale and
-re-label variables that are reported in thousands or millions.
+This package:
 
-Caches data for the duration of the current R session.
+* Downloads CANSIM/NDM tables as analysis-ready tidy data frames
+* Works with new NDM tables and legacy CANSIM table catalogue numbers
+* Bilingual
+* Caches downloaded data for faster loading and less waiting
+* Convenience functions for relabelling and rescaling when appropriate
 
-# Basic Usage
-Use old or new table number to download entire cansim tables into a tidy dataframe. 
+### Installation
+```r
+# install.packages("devtools")
+devtools::install_github("mountainmath/github")
+```
 
-    data <- get_cansim("051-0057")
-    data <- get_cansim("510057")
-    data <- get_cansim("17-10-0079")
-    data <- get_cansim("17-10-0079-01")
-    
-all load the same data.
-    
-To load french language data use
-  
-    data <- get_cansim("17-10-0079",language="french")
-    
-CANSIM data values may be scaled by powers of 10. For example, values in the VALUE field may be reported in "millions", so a VALUE of 10 means 10,000,000. The *normalize_cansim_values* function automatically scales the VALUE field to be a number, so the VALUE will be converted from 10 to 10000000 in the example given.
+### Caching
 
-    data <- get_cansim("17-10-0079-01") %>% normalize_cansim_values
-    
-To retain the original VALUE field and create a new NORMALIZED_VALUE field to contain the normailzed value, pass the *replace=FALSE* option.
+As many CANSIM table downloads can be quite large in size, the cansim package will temporarily cache data for the duration of the current R session. This reduces unnecessary waiting when recompiling code. 
 
-    data <- get_cansim("17-10-0079-01") %>% normalize_cansim_values(replace=FALSE)
-    
+### Basic Usage
+
+Use old or new table number to download entire CANSIM or NDM tables into a tidy dataframe. The cansim package retains the ability to work with legacy CANSIM table numbers or their new NDM equivalent. Calling either the legacy CANSIM table number or the new NDM number will load the same data. 
+```r
+# Retrieve data for births table: 17-10-0016-01 (formerly: CANSIM 051-0013)
+births <- get_cansim("051-0013")
+births <- get_cansim("17-10-0016-01")
+
+# Retrieve data for balance of payment table 36-10-0042-01 (formerly CANSIM  376-8105)
+bop <- get_cansim("3768105")
+bop <- get_cansim("36-10-0042")
+```    
+
+### Bilingual
+
+The cansim package works in either English or French. There is an optional language argument to retrieve CANSIM/NDM tables in French: 
+
+Le paquet cansim fonctionne en anglais ou en français. Il existe un argument de langue optionnel pour récupérer les tables CANSIM / NMD en français:
+```r
+naissances <- get_cansim("051-0013",language="fr")
+```    
+
+### Normalizing values
+
+The package also contains a convenience function that will re-scale and re-label variables that are reported in thousands or millions. CANSIM data values may be scaled by powers of 10. 
+
+For example, values in the VALUE field may be reported in "millions", so a VALUE of 10 means 10,000,000. The `normalize_cansim_values` function automatically scales the VALUE field to be a number, so the VALUE will be converted from 10 to 10000000 in the example given.
+```r
+data <- get_cansim("17-10-0079-01") %>% normalize_cansim_values
+``` 
+
+To retain the original VALUE field and create a new NORMALIZED_VALUE field to contain the normailzed value, pass the `replace=FALSE` option.
+```r
+data <- get_cansim("17-10-0079-01") %>% normalize_cansim_values(replace=FALSE)
+```
+
+### Encoding
+
+Tables are downloaded using the "raw" option is the default and variables are automatically read as numeric/character as appropriate. "Windows-1254" encoding is used during data reading to avoid issues with some labels messing with R.
+
+### Contributing
+
+This package is still under development and may have some bugs. [Issues](https://github.com/mountainMath/cansim/issues) and [pull requests](https://github.com/mountainMath/cansim/pulls) are highly appreciated. 
+
+### To-do
+
+- [ ] Clean up package and function documentation
+- [ ] Provide additional user control over cache location
+- [ ] Test for more bugs
+- [ ] Submit to CRAN
+
+### Related packages
+
+* There exists a [CANSIM2R package](https://cran.r-project.org/web/packages/CANSIM2R/index.html) on CRAN. This package currently uses some functionality from that package to access legacy CANSIM data. The *CANSIM2R* package currently does not support retrieval of data from Statistics Canada's NDM tables. 
+
+* [CANSIM-dataviewer](https://github.com/bcgov/CANSIM-dataviewer) is another tool that depends on the existing *CANSIM2R* package with a focus on uses for the Province of British Columbia.
+
+* [cancensus](https://github.com/mountainMath/cancensus) is a package designed to access, retrieve, and work with Canadian Census data and geography. A stable version is available on CRAN and a development version is on Github. 
+
+


### PR DESCRIPTION
This PR has a couple of commits:

1. Fixes breaking bug in `get_cansim` where some `mutate` calls were not properly namespaced and would break for anyone using this package. 

2. Rewrite of the main read me text to better explain and document. One key change is that the examples use different CANSIM tables that are much smaller in size and quicker to download. The table used in the original example was > 200mb and inappropriate for an example. 