### PR TITLE
require min R version for dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ Description: Searches for, accesses, and retrieves new-format and old-format CAN
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
+Depends: R (>= 2.10)
 Imports: dplyr (>= 0.7),
     httr (>= 1.0.0),
     readr,


### PR DESCRIPTION
Using .sysdata files requires R minimum version 2.10 as a dependency in the description, otherwise check will throw up warnings. This addresses that. 