### PR TITLE
add STC licensing details

### DIFF
--- a/R/Statistics Canada Open Licence Agreement
+++ b/R/Statistics Canada Open Licence Agreement
@@ -1,0 +1,64 @@
+Statistics Canada Open Licence Agreement
+This agreement is between Her Majesty the Queen in Right of Canada, as represented by the Minister for Statistics Canada ("Statistics Canada") and you (an individual or a legal entity that you are authorized to represent).
+
+The following are terms governing your use of the Information. Your use of any Information indicates your understanding and agreement to be bound by these terms. If you do not agree to these terms, you may not use the Information.
+
+Statistics Canada may modify this agreement at any time, and such modifications shall be effective immediately upon posting of the modified agreement on the Statistics Canada website. Your use of the Information will be governed by the terms of the agreement in force as of the date and time you accessed the Information.
+
+Definitions
+"Information" means any data files, data bases, tables, graphs, maps and text for which Statistics Canada is the owner or a licensee of all intellectual property rights and made available to you in accordance with this agreement, at cost or no cost, either on the Statistics Canada website or by other means as a result of a contract for goods or services.
+
+"Value-added Products" means any products you have produced by adapting or incorporating the Information, in whole or in part, in accordance with this agreement.
+Licence Grant
+Subject to this agreement, Statistics Canada grants you a worldwide, royalty-free, non-exclusive licence to:
+
+use, reproduce, publish, freely distribute, or sell the Information;
+use, reproduce, publish, freely distribute, or sell Value-added Products; and,
+sublicence any or all such rights, under terms consistent with this agreement.
+In doing any of the above, you shall:
+
+reproduce the Information accurately;
+not use the Information in a way that suggests that Statistics Canada endorses you or your use of the Information;
+not misrepresent the Information or its source;
+use the Information in a manner that does not breach or infringe any applicable laws;
+not merge or link the Information with any other databases for the purpose of attempting to identify an individual person, business or organization; and
+not present the Information in such a manner that gives the appearance that you may have received, or had access to, information held by Statistics Canada about any identifiable individual person, business or organization.
+Intellectual Property Rights
+Intellectual property rights, being any and all intellectual property rights recognized by the law, including but not limited to, intellectual property rights protected through legislation, in Value-added Products, shall vest in you, in such person as you shall decide or as determined by law.
+
+Intellectual property rights that Statistics Canada may have in the Information shall remain the property of Statistics Canada. Intellectual property rights that third parties may have in the Information shall remain their property.
+Acknowledgment of Source
+(a) You shall include and maintain the following notice on all licensed rights of the Information:
+
+Source: Statistics Canada, name of product, reference date. Reproduced and distributed on an "as is" basis with the permission of Statistics Canada.
+
+(b) Where any Information is contained within a Value-added Product, you shall include on such Value-added Product the following notice:
+
+Adapted from Statistics Canada, name of product, reference date. This does not constitute an endorsement by Statistics Canada of this product.
+Advertising and Publicity
+You shall not include on any reproduction of the Information or any material relating to your Value-added Product, or elsewhere:
+
+(a) the name, crest, logos or other insignia or domain names of Statistics Canada or the official symbols of the Government of Canada, including the Canada wordmark, the Coat of Arms of Canada, and the flag symbol, without written authorization from the Treasury Board Secretariat. Request for authorization from the Treasury Board Secretariat may be addressed to:
+
+information@fip-pcim.gc.ca
+Federal Identity Program
+Treasury Board of Canada Secretariat
+300 Laurier Avenue West
+Ottawa, Canada K1A 0R5
+
+(b) any annotation that may be interpreted as an endorsement by the Statistics Canada of the Value-added Product or that would imply that you have an exclusive distribution arrangement for any or all of the Information or that you have access to any confidential information or information not available to others.
+No Warranty and no Liability
+The Information is licensed 'as is', and Statistics Canada makes no representations or warranties whatsoever with respect to the Information, whether express or implied, in relation to the Information and expressly disclaims any implied warranty of merchantability or fitness for a particular purpose of the Information.
+
+Statistics Canada or any of its Ministers, officials, servants, employees, agents, successors and assigns shall not be liable for any errors or omissions in the Information and shall not, under any circumstances, be liable for any direct, indirect, special, incidental, consequential, or other loss, injury or damage, however caused, that you may suffer at any time by reason of your possession, access to or use of the Information or arising out of the exercise of your rights or the fulfilment of your obligations under this agreement.
+Term
+This agreement is effective as of the date and time you access the Information and shall terminate automatically if you breach any of the terms of this agreement.
+
+Notwithstanding termination of this agreement:
+
+you may continue to distribute Value-added Products for the purpose of completing orders made before the termination of this agreement provided you comply with the requirements set out in the Acknowledgment of Source clause; and
+individuals or entities who have received Value-added Products or reproductions of the Information from you pursuant to this agreement will not have their licences terminated provided they remain in full compliance with those licences.
+Survival
+All obligations which expressly or by their nature survive termination of this agreement shall continue in full force and effect. For greater clarity, and without limiting the generality of the foregoing, the following provisions survive expiration or termination of this agreement: Acknowledgment of Source, and No warranty and no Liability.
+Applicable Law
+This agreement shall be governed and construed in accordance with the laws of the province of Ontario and the laws of Canada applicable therein. The parties hereby attorn to the exclusive jurisdiction of the Federal Court of Canada.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,38 @@ data <- get_cansim("17-10-0079-01") %>% normalize_cansim_values(replacement_valu
 
 By default percentages will be converted to rates, so instead of being 0-100 it will be normalized to 0-1. To change that behaviour set *normalize_percent=FALSE*.
 
+### License
+
+The code in this package is licensed under the MIT license. The bundled table metadata in Sysdata.R, as well as all Statistics Canada data retrieved using this package is made available under the Statistics Canada Open Licence Agreement, a copy of which is included in the R folder. The Statistics Canada Open License Agreement requires that: 
+
+> Subject to this agreement, Statistics Canada grants you a worldwide, royalty-free, non-exclusive >licence to:
+> 
+> * use, reproduce, publish, freely distribute, or sell the Information;
+> * use, reproduce, publish, freely distribute, or sell Value-added Products; and,
+> * sublicence any or all such rights, under terms consistent with this agreement.
+> 
+> In doing any of the above, you shall:
+> 
+> * reproduce the Information accurately;
+> * not use the Information in a way that suggests that Statistics Canada endorses you or your use of the Information;
+> * not misrepresent the Information or its source;
+> * use the Information in a manner that does not breach or infringe any applicable laws;
+> * not merge or link the Information with any other databases for the purpose of attempting to identify an individual person, business or organization; and
+> * not present the Information in such a manner that gives the appearance that you may have received, or had access to, information held by Statistics Canada about any identifiable individual person, business or organization.
+
+### Attribution
+
+Subject to the Statistics Canada Open License Agreement, licensed products using Statistics Canada data should employ the following acknowledgement of source:
+
+> Acknowledgment of Source
+> (a) You shall include and maintain the following notice on all licensed rights of the Information:
+>
+> Source: Statistics Canada, name of product, reference date. Reproduced and distributed on an "as is" basis with the permission of Statistics Canada.
+> 
+> (b) Where any Information is contained within a Value-added Product, you shall include on such Value-added Product the following notice:
+> 
+> Adapted from Statistics Canada, name of product, reference date. This does not constitute an endorsement by Statistics Canada of this product.
+
 ### Contributing
 
 This package is under active development and may have some bugs. [Issues](https://github.com/mountainMath/cansim/issues) and [pull requests](https://github.com/mountainMath/cansim/pulls) are highly appreciated. 


### PR DESCRIPTION
This is overdue, but should clarify license issues as discussed in #32. 

I've added a text copy of the license in the R folder where sysdata lives, as well as detailed the license and key terms on the readme doc. As other documentation is built up and updated over the next little while, references to the license will be added as appropriate. 