### PR TITLE
defaults to viewing search page

### DIFF
--- a/R/cansim.R
+++ b/R/cansim.R
@@ -657,7 +657,8 @@ generate_table_metadata <- function(){
 #'
 #' Opens CANSIM table on Statistics Canada's website using default browser. This may be useful for getting further info on CANSIM table and survey methods.
 #'
-#' @param cansimTableNumber CANSIM or NDM table number
+#' @param cansimTableNumber CANSIM or NDM table number. If no number is provided, the vector search
+#' page on the Statistic Canada website will be opened.
 #'
 #' @return none
 #'
@@ -666,10 +667,16 @@ generate_table_metadata <- function(){
 #' view_cansim_webpage("34-10-0013")
 #' }
 #' @export
-view_cansim_webpage <- function(cansimTableNumber){
+view_cansim_webpage <- function(cansimTableNumber = NULL){
   browser <- getOption("browser")
-  cansimTableNumber <- paste0(gsub("-","",cleaned_ndm_table_number(cansimTableNumber)),"01")
-  url <- paste0("https://www150.statcan.gc.ca/t1/tbl1/en/tv.action?pid=",gsub("-","",cansimTableNumber))
+
+  if (is.null(cansimTableNumber)) {
+    url <- 'https://www150.statcan.gc.ca/t1/tbl1/en/sbv.action#tables'
+  } else {
+    cansimTableNumber <- paste0(gsub("-","",cleaned_ndm_table_number(cansimTableNumber)),"01")
+    url <- paste0("https://www150.statcan.gc.ca/t1/tbl1/en/tv.action?pid=",gsub("-","",cansimTableNumber))
+  }
+
   utils::browseURL(url,browser)
 }
 

--- a/man/view_cansim_webpage.Rd
+++ b/man/view_cansim_webpage.Rd
@@ -4,10 +4,11 @@
 \alias{view_cansim_webpage}
 \title{View CANSIM table information in browser}
 \usage{
-view_cansim_webpage(cansimTableNumber)
+view_cansim_webpage(cansimTableNumber = NULL)
 }
 \arguments{
-\item{cansimTableNumber}{CANSIM or NDM table number}
+\item{cansimTableNumber}{CANSIM or NDM table number. If no number is provided, the vector search
+page on the Statistic Canada website will be opened.}
 }
 \value{
 none


### PR DESCRIPTION
The PR will close #85 

I wasn't even thinking anything quite as involved as distinguishing between table numbers or vector number. Rather I was just thinking to make use of the fact that `view_cansim_webpage()` didn't have a default and a sensible one would be to take a user to the search site. 