### PR TITLE
update citation info

### DIFF
--- a/inst/CITATION
+++ b/inst/CITATION
@@ -1,0 +1,10 @@
+citHeader("To cite 'cansim' in publications please use:")
+
+bibentry(
+  "Manual",
+  year = {2021},
+  author = "Jens von Bergmann and Dmitry Shkolnik",
+  title = "cansim: Accessing Statistics Canada Data Table and Vectors",
+  url = "https://CRAN.R-project.org/package=cansim",
+  textVersion = "von Bergmann and Shkolnik (2021). cansim: Accessing Statistics Canada Data Table and Vectors. https://CRAN.R-project.org/package=cansim"
+)


### PR DESCRIPTION
Hope the unsolicited PR is ok here. Currently when one asks for a citation for cansim this is returned:

```r
R> citation("cansim")

To cite package 'cansim' in publications use:

  Dmitry Shkolnik (2021). cansim: Accessing Statistics Canada Data Table and Vectors. R
  package version 0.3.7. https://CRAN.R-project.org/package=cansim

A BibTeX entry for LaTeX users is

  @Manual{,
    title = {cansim: Accessing Statistics Canada Data Table and Vectors},
    author = {Dmitry Shkolnik},
    year = {2021},
    note = {R package version 0.3.7},
    url = {https://CRAN.R-project.org/package=cansim},
  }
  ```

I have no idea why this is happening. However, this does seem out of line with the [DESCRIPTION](https://github.com/mountainMath/cansim/blob/master/DESCRIPTION) file. This PR is to suggest modifying the CITATION file so that `citation` returns something like this:

```r
R> citation("cansim")

To cite 'cansim' in publications please use:

  von Bergmann and Shkolnik (2021). cansim: Accessing Statistics Canada Data Table and
  Vectors. https://CRAN.R-project.org/package=cansim

A BibTeX entry for LaTeX users is

  @Manual{,
    year = {2021},
    author = {Jens {von Bergmann} and Dmitry Shkolnik},
    title = {cansim: Accessing Statistics Canada Data Table and Vectors},
    url = {https://CRAN.R-project.org/package=cansim},
  }
  ```
  
  Whatever you land on (and no worries if it doesn't come from this PR) this might be worth changing. Thanks for this great package!



