### PR TITLE
Fix typo in README.md call of get_cansim_table_overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ More detailed usage examples are available in the _Retrieving individual Statist
 
 The `get_cansim_table_overview` function displays an overview of table information. If the table is not yet downloaded and cached it will first download the table itself. Let's take a look what's in the table we are interested in.
 ```{r}
-get_cansim_table_overview(36-10-040)
+get_cansim_table_overview("36-10-040")
 ```
 
 ### Listing available tables


### PR DESCRIPTION
Calling as written in README threw an error:

```
Error in cansim_old_to_new(t) : 
  Unable to match old CANSIM table number 0000014
In addition: Warning message:
In cleaned_ndm_table_number(cansimTableNumber) :
  The cansim table number -14 used in this query is numeric,
it is safer to encode table numbers as character strings.
```