### PR TITLE
Optimize get_cansim_table_template() with expand_grid

### DIFF
--- a/R/cansim_metadata.R
+++ b/R/cansim_metadata.R
@@ -363,31 +363,43 @@ get_cansim_table_template <- function(cansimTableNumber, language="english",refr
   dimensions <- member_info %>%
     select("dimensionPositionId", "dimensionName") %>%
     unique() %>%
-    arrange("dimensionPositionId")
+    arrange(.data$dimensionPositionId)
 
-  result <- tibble(...link="link",COORDINATE="")
+  # Build dimension data for expand_grid (more efficient than iterative full_join)
+  dim_list <- list()
+  dim_names <- character(nrow(dimensions))
+  member_id_cols <- character(nrow(dimensions))
 
   for (i in seq_len(nrow(dimensions))) {
     dim <- dimensions[i,]
     dim_name <- dim$dimensionName
-    member <- member_info %>%
-      filter(.data$dimensionPositionId==dim$dimensionPositionId) %>%
-      select("memberId", "memberName") %>%
-      unique() %>%
-      arrange("memberId") %>%
-      rename(!!dim_name:="memberName") %>%
-      mutate(...link="link")
+    dim_names[i] <- dim_name
+    member_id_col <- paste0("...mid_", i)
+    member_id_cols[i] <- member_id_col
 
-    result <- result %>%
-      full_join(member, by="...link",
-                relationship = "many-to-many") %>%
-      mutate(COORDINATE=ifelse(.data$COORDINATE=="", .data$memberId, paste0(.data$COORDINATE, ".", .data$memberId))) %>%
-      select(-any_of("memberId"))
+    members <- member_info %>%
+      filter(.data$dimensionPositionId == dim$dimensionPositionId) %>%
+      select("memberId", "memberName") %>%
+      unique()
+
+    dim_data <- tibble(
+      !!dim_name := members$memberName,
+      !!member_id_col := members$memberId
+    )
+    dim_list[[i]] <- dim_data
   }
 
+  # Create Cartesian product in one operation
+  result <- do.call(tidyr::expand_grid, dim_list)
+
+  # Build COORDINATE column using vectorized paste
+  coord_cols <- lapply(member_id_cols, function(col) result[[col]])
+  result$COORDINATE <- do.call(paste, c(coord_cols, sep = "."))
+
+  # Reorder columns: cansimTableNumber, COORDINATE, then dimension columns
   result <- result %>%
-    select(-any_of("...link")) %>%
-    mutate(cansimTableNumber=!!cansimTableNumber,.before="COORDINATE")
+    mutate(cansimTableNumber = !!cansimTableNumber) %>%
+    select("cansimTableNumber", "COORDINATE", all_of(dim_names))
 
   attr(result, "cansimTableNumber") <- cansimTableNumber
   attr(result, "langauge") <- language


### PR DESCRIPTION
## Summary

Optimize `get_cansim_table_template()` by replacing iterative `full_join` operations with a single `tidyr::expand_grid()` call.

### Before (iterative approach)
```r
result <- tibble(...link="link", COORDINATE="")
for (i in seq_len(nrow(dimensions))) {
  result <- result %>%
    full_join(member, by="...link", relationship="many-to-many") %>%
    mutate(COORDINATE=ifelse(COORDINATE=="", memberId, paste0(COORDINATE, ".", memberId)))
}
```

### After (vectorized approach)
```r
result <- do.call(tidyr::expand_grid, dim_list)
coord_cols <- lapply(member_id_cols, function(col) result[[col]])
result$COORDINATE <- do.call(paste, c(coord_cols, sep="."))
```

## Benchmark Results

Tested with installed package versions (mean of 5 runs each):

| Table | Rows | Original | Optimized | Speedup |
|-------|------|----------|-----------|---------|
| 34-10-0013 | 50 | 0.0148s | 0.0084s | **43%** |
| 20-10-0001 | 660 | 0.0270s | 0.0152s | **44%** |
| 36-10-0402 | 13,143 | 0.0266s | 0.0168s | **37%** |
| 14-10-0287 | 32,076 | 0.0482s | 0.0294s | **39%** |
| 13-10-0096 | 66,528 | 0.0500s | 0.0398s | **20%** |

## Correctness Verification

Output verified identical to original on all test tables:
- Column names match: ✓
- Row counts match: ✓
- Data identical (when sorted by COORDINATE): ✓

```
Table 34-10-0013: Columns identical: TRUE, Data identical (sorted): TRUE
Table 20-10-0001: Columns identical: TRUE, Data identical (sorted): TRUE
Table 14-10-0287: Columns identical: TRUE, Data identical (sorted): TRUE
```

## Test Plan
- [x] All existing tests pass (`devtools::test()` - 20 tests)
- [x] Output verified identical on multiple tables
- [x] Benchmarked with installed package versions

🤖 Generated with [Claude Code](https://claude.ai/code)