### PR TITLE
Optimize date parsing in normalize_cansim_values

### DIFF
--- a/R/cansim.R
+++ b/R/cansim.R
@@ -98,20 +98,37 @@ normalize_cansim_values <- function(data, replacement_value="val_norm", normaliz
   if (!trad_cansim) {
     # do nothing
   } else if (grepl("^\\d{4}$",sample_date)) {
-    # year
-    data <- data %>%
-      mutate(Date=as.Date(paste0(!!as.name(date_field),"-",default_month,"-",default_day)))
+    # year - use lookup table for efficiency
+    unique_dates <- unique(data[[date_field]])
+    date_lookup <- setNames(
+      as.Date(paste0(unique_dates, "-", default_month, "-", default_day)),
+      unique_dates
+    )
+    data$Date <- unname(date_lookup[data[[date_field]]])
   } else if (grepl("^\\d{4}/\\d{4}$",sample_date)) {
-    # year range, use second year as anchor
-    data <- data %>%
-      mutate(Date=as.Date(paste0(gsub("^\\d{4}/","",!!as.name(date_field)),"-",default_month,"-",default_day)))
+    # year range, use second year as anchor - use lookup table for efficiency
+    unique_dates <- unique(data[[date_field]])
+    date_lookup <- setNames(
+      as.Date(paste0(gsub("^\\d{4}/", "", unique_dates), "-", default_month, "-", default_day)),
+      unique_dates
+    )
+    data$Date <- unname(date_lookup[data[[date_field]]])
   } else if (grepl("^\\d{4}-\\d{2}$",sample_date)) {
-    # year and month
-    data <- data %>% mutate(Date=as.Date(paste0(!!as.name(date_field),"-",default_day)))
+    # year and month - use lookup table for efficiency
+    unique_dates <- unique(data[[date_field]])
+    date_lookup <- setNames(
+      as.Date(paste0(unique_dates, "-", default_day)),
+      unique_dates
+    )
+    data$Date <- unname(date_lookup[data[[date_field]]])
   } else if (grepl("^\\d{4}-\\d{2}-\\d{2}$",sample_date)) {
-    # year, month and day
-    data <- data %>%
-      mutate(Date=as.Date(!!as.name(date_field)))
+    # year, month and day - use lookup table for efficiency
+    unique_dates <- unique(data[[date_field]])
+    date_lookup <- setNames(
+      as.Date(unique_dates),
+      unique_dates
+    )
+    data$Date <- unname(date_lookup[data[[date_field]]])
   }
 
   cansimTableNumber <- cleaned_ndm_table_number(cansimTableNumber)


### PR DESCRIPTION
## Summary
- Replaces row-by-row `as.Date()` calls with lookup table approach
- For large tables (millions of rows), date parsing was a major bottleneck
- Builds lookup table from unique date values (typically hundreds/thousands), then uses fast vector indexing

## Benchmark Results

**Table 14-10-0287** (5,394,600 rows, year-month format):

| Version | Mean Time | Min | Max |
|---------|-----------|-----|-----|
| Original | 85.81 sec | 82.56 | 90.02 |
| Optimized | 66.97 sec | 64.88 | 69.09 |
| **Improvement** | **22% faster** | | |

The optimization saves ~19 seconds on get_cansim() for this large table.

## Verification
- Output is identical to original for all tested tables
- All unit tests pass (20/20)

## Test Tables
- 20-10-0001 (163K rows, year-month format): IDENTICAL output
- 14-10-0287 (5.4M rows, year-month format): IDENTICAL output  
- 34-10-0013 (550 rows, year format): IDENTICAL output

🤖 Generated with [Claude Code](https://claude.com/claude-code)